### PR TITLE
feat: system now waits 1 second before sending zero address, checks for connected

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dist",
     "src"
   ],
-  "version": "1.1.39",
+  "version": "1.2.1",
   "description": "Typescript client for Prism protocol onchain advertising",
   "scripts": {
     "build": "tsup",

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,8 +103,8 @@ export class PrismClient {
      */
     private static readonly DEFAULT_CONFIG = {
         retries: 3,
-        timeout: 10000, // 10 seconds
-        walletDetectionTimeout: 1000, // 3 seconds to wait for wallet
+        timeout: 10000, 
+        walletDetectionTimeout: 1000,
         walletDetectionInterval: 100, // Check every 100ms
     };
 

--- a/test/auction.test.ts
+++ b/test/auction.test.ts
@@ -1,0 +1,42 @@
+import { PrismClient, PrismWinner } from "../src/index";
+import { expect, it, describe, vi } from 'vitest';
+import { setupTestEnv, PUBLISHER_ADDRESS, PUBLISHER_DOMAIN, USER_WALLET, CAMPAIGN_ID, MOCK_JWT_TOKEN, mockSubtleCrypto } from './setupTestEnv';
+
+setupTestEnv();
+
+describe('PrismClient Auction', () => {
+    it('should call encryptAddress and return campaign data', async () => {
+        const auctionResult: PrismWinner = await PrismClient.auction(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            USER_WALLET
+        );
+
+        expect(mockSubtleCrypto.importKey).toHaveBeenCalledTimes(1);
+        expect(mockSubtleCrypto.encrypt).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/auction'), 
+            expect.objectContaining({
+                body: expect.stringContaining(Buffer.from(`encrypted-${USER_WALLET}_by_mocked_subtle_encrypt`).toString('base64'))
+            })
+        );
+        expect(auctionResult.jwt_token).toBe(MOCK_JWT_TOKEN);
+        expect(auctionResult.campaignId).toBe(CAMPAIGN_ID);
+    });
+
+    it('should call onSuccess callback when provided', async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        await PrismClient.auction(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            USER_WALLET,
+            { onSuccess, onError }
+        );
+
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onError).not.toHaveBeenCalled();
+    });
+});

--- a/test/autoAuction.test.ts
+++ b/test/autoAuction.test.ts
@@ -1,0 +1,53 @@
+import { PrismClient, PrismWinner } from "../src/index";
+import { expect, it, describe, vi } from 'vitest';
+import { setupTestEnv, PUBLISHER_ADDRESS, PUBLISHER_DOMAIN, USER_WALLET, UNCONNECTED_WALLET, CAMPAIGN_ID, MOCK_JWT_TOKEN } from './setupTestEnv';
+
+setupTestEnv();
+
+describe('PrismClient autoAuction', () => {
+    it('should use connected wallet when provided', async () => {
+        const auctionResult: PrismWinner = await PrismClient.autoAuction(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            USER_WALLET
+        );
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/auction'),
+            expect.objectContaining({
+                body: expect.stringContaining(Buffer.from(`encrypted-${USER_WALLET}_by_mocked_subtle_encrypt`).toString('base64'))
+            })
+        );
+        expect(auctionResult.jwt_token).toBe(MOCK_JWT_TOKEN);
+        expect(auctionResult.campaignId).toBe(CAMPAIGN_ID);
+    });
+
+    it('should use unconnected wallet address when no wallet provided', async () => {
+        const auctionResult: PrismWinner = await PrismClient.autoAuction(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN
+        );
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/auction'),
+            expect.objectContaining({
+                body: expect.stringContaining(Buffer.from(`encrypted-${UNCONNECTED_WALLET}_by_mocked_subtle_encrypt`).toString('base64'))
+            })
+        );
+        expect(auctionResult.jwt_token).toBe(MOCK_JWT_TOKEN);
+        expect(auctionResult.campaignId).toBe(CAMPAIGN_ID);
+    });
+
+    it('should call onSuccess callback when provided', async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+        await PrismClient.autoAuction(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            USER_WALLET,
+            { onSuccess, onError }
+        );
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onError).not.toHaveBeenCalled();
+    });
+});

--- a/test/callbacks.test.ts
+++ b/test/callbacks.test.ts
@@ -1,0 +1,33 @@
+import { PrismClient, PrismWinner } from "../src/index";
+import { expect, it, describe, vi } from 'vitest';
+import { setupTestEnv, PUBLISHER_ADDRESS, PUBLISHER_DOMAIN, USER_WALLET, MOCK_JWT_TOKEN } from './setupTestEnv';
+
+const { fetchMock } = setupTestEnv();
+
+describe('PrismClient Callbacks', () => {
+    it('auction should call onSuccess callback when provided', async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+        await PrismClient.auction(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            USER_WALLET,
+            { onSuccess, onError }
+        );
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('autoAuction should call onSuccess callback when provided', async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+        await PrismClient.autoAuction(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            USER_WALLET,
+            { onSuccess, onError }
+        );
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onError).not.toHaveBeenCalled();
+    });
+});

--- a/test/clicks.test.ts
+++ b/test/clicks.test.ts
@@ -1,0 +1,35 @@
+import { PrismClient, PrismResponse } from "../src/index";
+import { expect, it, describe, vi } from 'vitest';
+import { setupTestEnv, PUBLISHER_ADDRESS, WEBSITE_URL, CAMPAIGN_ID, MOCK_JWT_TOKEN } from './setupTestEnv';
+
+setupTestEnv();
+
+describe('PrismClient Clicks', () => {
+    it('should succeed with a valid JWT token', async () => {
+        const clickResult: PrismResponse = await PrismClient.clicks(
+            PUBLISHER_ADDRESS,
+            WEBSITE_URL,
+            CAMPAIGN_ID,
+            MOCK_JWT_TOKEN
+        );
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(clickResult.status).toBe(200);
+        expect((clickResult.data as any).status).toBe("success");
+    });
+
+    it('should call onSuccess callback when provided', async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        await PrismClient.clicks(
+            PUBLISHER_ADDRESS,
+            WEBSITE_URL,
+            CAMPAIGN_ID,
+            MOCK_JWT_TOKEN,
+            { onSuccess, onError }
+        );
+
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onError).not.toHaveBeenCalled();
+    });
+});

--- a/test/encryptAddress.test.ts
+++ b/test/encryptAddress.test.ts
@@ -1,0 +1,21 @@
+import { PrismClient } from "../src/index";
+import { expect, it, describe } from 'vitest';
+import { setupTestEnv, USER_WALLET, mockSubtleCrypto } from './setupTestEnv';
+
+setupTestEnv();
+
+describe('PrismClient encryptAddress', () => {
+    it('should use mocked window.crypto.subtle and btoa', async () => {
+        const encryptedAddress = await PrismClient.encryptAddress(USER_WALLET);
+        expect(mockSubtleCrypto.importKey).toHaveBeenCalledTimes(1);
+        expect(mockSubtleCrypto.encrypt).toHaveBeenCalledTimes(1);
+        const expectedEncryptedStringViaMock = `encrypted-${USER_WALLET}_by_mocked_subtle_encrypt`;
+        const expectedBase64Output = Buffer.from(expectedEncryptedStringViaMock, 'binary').toString('base64');
+        expect(encryptedAddress).toBe(expectedBase64Output);
+        expect(typeof encryptedAddress).toBe('string');
+        expect(encryptedAddress.length).toBeGreaterThan(0);
+        const intermediateEncryptedBytes = new TextEncoder().encode(expectedEncryptedStringViaMock);
+        const finalBtoaOutput = btoa(String.fromCharCode(...new Uint8Array(intermediateEncryptedBytes.buffer)));
+        expect(encryptedAddress).toBe(finalBtoaOutput);
+    });
+});

--- a/test/impressions.test.ts
+++ b/test/impressions.test.ts
@@ -1,0 +1,35 @@
+import { PrismClient, PrismResponse } from "../src/index";
+import { expect, it, describe, vi } from 'vitest';
+import { setupTestEnv, PUBLISHER_ADDRESS, WEBSITE_URL, CAMPAIGN_ID, MOCK_JWT_TOKEN } from './setupTestEnv';
+
+setupTestEnv();
+
+describe('PrismClient Impressions', () => {
+    it('should succeed with a valid JWT token', async () => {
+        const impressionResult: PrismResponse = await PrismClient.impressions(
+            PUBLISHER_ADDRESS,
+            WEBSITE_URL,
+            CAMPAIGN_ID,
+            MOCK_JWT_TOKEN
+        );
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(impressionResult.status).toBe(200);
+        expect((impressionResult.data as any).status).toBe("success");
+    });
+
+    it('should call onSuccess callback when provided', async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        await PrismClient.impressions(
+            PUBLISHER_ADDRESS,
+            WEBSITE_URL,
+            CAMPAIGN_ID,
+            MOCK_JWT_TOKEN,
+            { onSuccess, onError }
+        );
+
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onError).not.toHaveBeenCalled();
+    });
+});

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,0 +1,57 @@
+import { PrismClient } from "../src/index";
+import { expect, it, describe, vi } from 'vitest';
+import { setupTestEnv, PUBLISHER_ADDRESS, PUBLISHER_DOMAIN, USER_WALLET, MOCK_JWT_TOKEN } from './setupTestEnv';
+
+setupTestEnv();
+
+describe('PrismClient init', () => {
+    it('should trigger auto auction by default and call success callback', async () => {
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+        const result = await PrismClient.init(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            {
+                connectedWallet: USER_WALLET,
+                onSuccess,
+                onError
+            }
+        );
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onError).not.toHaveBeenCalled();
+        expect(result).toBeTruthy();
+        expect(result?.jwt_token).toBe(MOCK_JWT_TOKEN);
+    });
+
+    it('should not trigger auction when autoTrigger is false', async () => {
+        const result = await PrismClient.init(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            {
+                autoTrigger: false
+            }
+        );
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(result).toBeNull();
+    });
+
+    it('should call error callback when auction fails', async () => {
+        const fetchSpy = vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+        const result = await PrismClient.init(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            {
+                onSuccess,
+                onError
+            }
+        );
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        expect(result).toBeNull();
+        fetchSpy.mockRestore();
+    });
+});

--- a/test/retryTimeout.test.ts
+++ b/test/retryTimeout.test.ts
@@ -1,0 +1,61 @@
+import { PrismClient, PrismWinner } from "../src/index";
+import { expect, it, describe, vi } from 'vitest';
+import { setupTestEnv, PUBLISHER_ADDRESS, PUBLISHER_DOMAIN, USER_WALLET, CAMPAIGN_ID, MOCK_JWT_TOKEN } from './setupTestEnv';
+
+setupTestEnv();
+
+describe('PrismClient Retry and Timeout', () => {
+    it('should retry failed requests with exponential backoff', async () => {
+        const fetchSpy = vi.spyOn(global, 'fetch');
+        fetchSpy.mockRejectedValueOnce(new Error('Network error'));
+        fetchSpy.mockRejectedValueOnce(new Error('Network error'));
+        fetchSpy.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({
+                data: {
+                    jwt_token: MOCK_JWT_TOKEN,
+                    campaignId: CAMPAIGN_ID,
+                    bannerIpfsUri: "https://example.com/banner.png",
+                    url: "https://example.com/campaign-target",
+                    campaignName: "Test Campaign"
+                }
+            })
+        } as Response);
+
+        const result = await PrismClient.autoAuction(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            USER_WALLET,
+            { retries: 3 }
+        );
+        expect(global.fetch).toHaveBeenCalledTimes(3);
+        expect(result.jwt_token).toBe(MOCK_JWT_TOKEN);
+        fetchSpy.mockRestore();
+    });
+
+    it('should handle timeout errors correctly', async () => {
+        const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(() => {
+            return new Promise((_, reject) => {
+                setTimeout(() => {
+                    const abortError = new Error('AbortError');
+                    abortError.name = 'AbortError';
+                    reject(abortError);
+                }, 150);
+            });
+        });
+        const onError = vi.fn();
+        try {
+            await PrismClient.autoAuction(
+                PUBLISHER_ADDRESS,
+                PUBLISHER_DOMAIN,
+                USER_WALLET,
+                { timeout: 100, retries: 1, onError }
+            );
+        } catch (error) {
+            expect(error).toBeDefined();
+        }
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        fetchSpy.mockRestore();
+    }, 10000);
+});

--- a/test/setupTestEnv.ts
+++ b/test/setupTestEnv.ts
@@ -1,0 +1,146 @@
+// Shared test setup for PrismClient SDK tests
+import { vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+
+export const PUBLISHER_ADDRESS = "0xFa000000000000000000000000005F723DC";
+export const PUBLISHER_DOMAIN = "example.com";
+export const WEBSITE_URL = "https://example.com/article";
+export const USER_WALLET = "0xFa21000000000000000000000001BD35F723DC";
+export const UNCONNECTED_WALLET = "0x0000000000000000000000000000000000000000";
+export const CAMPAIGN_ID = "campaign-123";
+export const MOCK_JWT_TOKEN = "mock-jwt-token-for-testing";
+
+export const mockSubtleCrypto = {
+    importKey: vi.fn().mockResolvedValue({} as CryptoKey),
+    encrypt: vi.fn().mockImplementation(async (_algorithm: AlgorithmIdentifier, _key: CryptoKey, data: BufferSource) => {
+        const Suffix = "_by_mocked_subtle_encrypt";
+        let dataView: ArrayBufferView;
+        if (data instanceof ArrayBuffer) {
+            dataView = new Uint8Array(data);
+        } else if (ArrayBuffer.isView(data)) {
+            dataView = data;
+        } else {
+            throw new Error("Mock encrypt expects ArrayBuffer or ArrayBufferView");
+        }
+        const dataString = new TextDecoder().decode(dataView);
+        const encryptedString = `encrypted-${dataString}${Suffix}`;
+        return new TextEncoder().encode(encryptedString).buffer;
+    }),
+    decrypt: vi.fn(),
+    deriveBits: vi.fn(),
+    deriveKey: vi.fn(),
+    digest: vi.fn(),
+    exportKey: vi.fn(),
+    generateKey: vi.fn(),
+    sign: vi.fn(),
+    unwrapKey: vi.fn(),
+    verify: vi.fn(),
+    wrapKey: vi.fn()
+};
+
+let originalFetch: any;
+let fetchMock: any;
+let originalWindow: any;
+let originalAtob: any;
+let originalBtoa: any;
+
+export function setupTestEnv() {
+    beforeAll(() => {
+        originalWindow = (global as any).window;
+        originalAtob = global.atob;
+        originalBtoa = global.btoa;
+
+        global.atob = (str: string) => Buffer.from(str, 'base64').toString('binary');
+        global.btoa = (str: string) => Buffer.from(str, 'binary').toString('base64');
+        (global as any).window = {
+            crypto: {
+                subtle: mockSubtleCrypto,
+                getRandomValues: vi.fn((array) => {
+                    if (array.length) {
+                        for (let i = 0; i < array.length; i++) {
+                            array[i] = Math.floor(Math.random() * 256);
+                        }
+                    }
+                    return array;
+                }),
+                randomUUID: vi.fn().mockReturnValue('mock-uuid-in-beforeall')
+            }
+        };
+    });
+
+    afterAll(() => {
+        (global as any).window = originalWindow;
+        global.atob = originalAtob;
+        global.btoa = originalBtoa;
+    });
+
+    beforeEach(() => {
+        mockSubtleCrypto.importKey.mockClear().mockResolvedValue({} as CryptoKey);
+        mockSubtleCrypto.encrypt.mockClear().mockImplementation(async (_algorithm: AlgorithmIdentifier, _key: CryptoKey, data: BufferSource) => {
+            const Suffix = "_by_mocked_subtle_encrypt";
+            let dataView: ArrayBufferView;
+            if (data instanceof ArrayBuffer) {
+                dataView = new Uint8Array(data);
+            } else if (ArrayBuffer.isView(data)) {
+                dataView = data;
+            } else {
+                throw new Error("Mock encrypt expects ArrayBuffer or ArrayBufferView");
+            }
+            const dataString = new TextDecoder().decode(dataView);
+            const encryptedString = `encrypted-${dataString}${Suffix}`;
+            return new TextEncoder().encode(encryptedString).buffer;
+        });
+
+        fetchMock = vi.fn(async (url: string | URL | Request, _options?: RequestInit): Promise<Response> => {
+            let responseBody: any;
+            const urlString = url.toString();
+
+            if (urlString.includes('/auction')) {
+                responseBody = {
+                    status: "success",
+                    data: {
+                        jwt_token: MOCK_JWT_TOKEN,
+                        campaignId: CAMPAIGN_ID,
+                        bannerIpfsUri: "https://example.com/banner.png",
+                        url: "https://example.com/campaign-target",
+                        campaignName: "Test Campaign"
+                    }
+                };
+            } else if (urlString.includes('/click') || urlString.includes('/impressions')) {
+                responseBody = {
+                    data: {
+                        status: "success",
+                        message: `${urlString.includes('/click') ? 'Click' : 'Impression'} recorded successfully.`
+                    }
+                };
+            } else {
+                responseBody = {
+                    status: "error",
+                    message: "Unknown endpoint for mock"
+                };
+            }
+            
+            const responseText = JSON.stringify(responseBody);
+            const mockResponse = new Response(responseText, {
+                status: 200,
+                statusText: "OK",
+                headers: { 'Content-Type': 'application/json' }
+            });
+
+            Object.defineProperty(mockResponse, 'json', {
+                writable: true,
+                value: vi.fn().mockResolvedValue(responseBody)
+            });
+
+            return Promise.resolve(mockResponse);
+        });
+        originalFetch = global.fetch;
+        global.fetch = fetchMock;
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        vi.clearAllMocks();
+    });
+
+    return { fetchMock };
+}

--- a/test/walletDetection.test.ts
+++ b/test/walletDetection.test.ts
@@ -1,0 +1,174 @@
+import { PrismClient } from "../src/index";
+import { expect, it, describe, vi } from 'vitest';
+import { setupTestEnv, PUBLISHER_ADDRESS, PUBLISHER_DOMAIN, USER_WALLET, UNCONNECTED_WALLET, MOCK_JWT_TOKEN } from './setupTestEnv';
+
+setupTestEnv();
+
+describe('Wallet Detection', () => {
+    it('should use getWalletAddress when wallet is immediately available', async () => {
+        const getWalletAddress = vi.fn().mockReturnValue(USER_WALLET);
+        const onSuccess = vi.fn();
+
+        const result = await PrismClient.init(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            { getWalletAddress, onSuccess }
+        );
+
+        expect(getWalletAddress).toHaveBeenCalled();
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(result?.jwt_token).toBe(MOCK_JWT_TOKEN);
+    });
+
+    it('should wait for wallet address and use it when it becomes available', async () => {
+        let callCount = 0;
+        const getWalletAddress = vi.fn().mockImplementation(() => {
+            callCount++;
+            return callCount >= 3 ? USER_WALLET : undefined;
+        });
+        const onSuccess = vi.fn();
+
+        const result = await PrismClient.init(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            {
+                getWalletAddress,
+                walletDetectionTimeout: 1000,
+                walletDetectionInterval: 50,
+                onSuccess
+            }
+        );
+
+        expect(getWalletAddress).toHaveBeenCalledTimes(3);
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(result?.jwt_token).toBe(MOCK_JWT_TOKEN);
+    });
+
+    it('should fallback to unconnected state when wallet detection times out', async () => {
+        const getWalletAddress = vi.fn().mockReturnValue(undefined);
+        const onSuccess = vi.fn();
+
+        const result = await PrismClient.init(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            {
+                getWalletAddress,
+                walletDetectionTimeout: 200,
+                walletDetectionInterval: 50,
+                onSuccess
+            }
+        );
+
+        expect(getWalletAddress).toHaveBeenCalledTimes(4);
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(result?.jwt_token).toBe(MOCK_JWT_TOKEN);
+    });
+
+    it('should ignore zero address from getWalletAddress and wait for real address', async () => {
+        let callCount = 0;
+        const getWalletAddress = vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) return UNCONNECTED_WALLET;
+            if (callCount >= 3) return USER_WALLET;
+            return undefined;
+        });
+        const onSuccess = vi.fn();
+
+        const result = await PrismClient.init(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            {
+                getWalletAddress,
+                walletDetectionTimeout: 500,
+                walletDetectionInterval: 50,
+                onSuccess
+            }
+        );
+
+        expect(getWalletAddress).toHaveBeenCalledTimes(3);
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(result?.jwt_token).toBe(MOCK_JWT_TOKEN);
+    });
+
+    it('should handle errors from getWalletAddress gracefully', async () => {
+        let callCount = 0;
+        const getWalletAddress = vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount <= 2) throw new Error('Wallet not ready');
+            return USER_WALLET;
+        });
+        const onSuccess = vi.fn();
+
+        const result = await PrismClient.init(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            {
+                getWalletAddress,
+                walletDetectionTimeout: 500,
+                walletDetectionInterval: 50,
+                onSuccess
+            }
+        );
+
+        expect(getWalletAddress).toHaveBeenCalledTimes(3);
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(result?.jwt_token).toBe(MOCK_JWT_TOKEN);
+    });
+
+    it('should use connectedWallet parameter over getWalletAddress', async () => {
+        const getWalletAddress = vi.fn().mockReturnValue('0x9999999999999999999999999999999999999999');
+        const onSuccess = vi.fn();
+
+        const result = await PrismClient.init(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            {
+                connectedWallet: USER_WALLET,
+                getWalletAddress,
+                onSuccess
+            }
+        );
+
+        expect(getWalletAddress).not.toHaveBeenCalled();
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(result?.jwt_token).toBe(MOCK_JWT_TOKEN);
+    });
+
+    it('should work with async getWalletAddress', async () => {
+        const getWalletAddress = vi.fn().mockImplementation(async () => {
+            await new Promise(resolve => setTimeout(resolve, 100));
+            return USER_WALLET;
+        });
+        const onSuccess = vi.fn();
+
+        const result = await PrismClient.init(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            {
+                getWalletAddress,
+                walletDetectionTimeout: 500,
+                onSuccess
+            }
+        );
+
+        expect(getWalletAddress).toHaveBeenCalled();
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(result?.jwt_token).toBe(MOCK_JWT_TOKEN);
+    });
+
+    it('should not call getWalletAddress when autoTrigger is false', async () => {
+        const getWalletAddress = vi.fn().mockReturnValue(USER_WALLET);
+
+        const result = await PrismClient.init(
+            PUBLISHER_ADDRESS,
+            PUBLISHER_DOMAIN,
+            {
+                getWalletAddress,
+                autoTrigger: false
+            }
+        );
+
+        expect(getWalletAddress).not.toHaveBeenCalled();
+        expect(result).toBeNull();
+    });
+});


### PR DESCRIPTION
Usecase:
- If a users wallet is already set to auto-connect to a page, the address is not available to the SDK instantly so a non-connected request is sent, and then another connected request is sent straight after. This causes 2 requests.
- Now, the publisher provides a simple function that returns the user address. this function is polled every 100ms for the first 1 second of the page loading. If it hasn't received the address within the specified time, it will send the unconnected request.